### PR TITLE
Fix build scripts due to Debian 9 EOL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         run: ./build_uuidtob62.sh
       - name: check the outputs
         run: |
-          file build-ev3/sling build-ev3/sinter_host file build-ev3/executables/show_qrcode build-ev3/executables/nus_login build-ev3/executables/uuidtob62
+          file build-ev3/sling build-ev3/sinter_host file build-ev3/executables/show_qrcode build-ev3/executables/uuidtob62
       - name: make vmlinuz readable
         run: sudo chmod 755 /boot/vmlinuz*
       - name: build image

--- a/Dockerfile.sling
+++ b/Dockerfile.sling
@@ -1,2 +1,19 @@
 FROM ev3dev/debian-stretch-cross
-RUN ["sudo", "bash", "-c", "apt-get update && apt-get install --yes debian-keyring debian-archive-keyring && apt-key update && echo deb http://deb.debian.org/debian stretch-backports main > /etc/apt/sources.list.d/backports.list && echo deb http://deb.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/backports.list && apt-get update && apt-get install --yes --no-install-recommends -t stretch-backports-sloppy libarchive13 && apt-get install --yes --no-install-recommends -t stretch-backports cmake && apt-get install --yes --no-install-recommends libssl-dev:armel"]
+
+# Fix for Debian Stretch end-of-life
+# Adapted from https://stackoverflow.com/a/76095392
+RUN sudo sed -i -e 's/deb.debian.org/archive.debian.org/g' \
+                -e 's/ftp.debian.org/archive.debian.org/g' \
+                -e 's|security.debian.org|archive.debian.org/|g' \
+                -e '/stretch\/updates/d' \
+                -e '/stretch-updates/d' /etc/apt/sources.list
+
+RUN sudo bash -c "apt-get update && \
+                  apt-get install --yes debian-keyring debian-archive-keyring && \
+                  apt-key update && \
+                  echo deb http://archive.debian.org/debian stretch-backports main > /etc/apt/sources.list.d/backports.list && \
+                  echo deb http://archive.debian.org/debian stretch-backports-sloppy main >> /etc/apt/sources.list.d/backports.list && \
+                  apt-get update && \
+                  apt-get install --yes --no-install-recommends -t stretch-backports-sloppy libarchive13 && \
+                  apt-get install --yes --no-install-recommends -t stretch-backports cmake && \
+                  apt-get install --yes --no-install-recommends libssl-dev:armel"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ To build the image from the source code, make sure you are the the root of the r
 ```bash
 wget https://raw.githubusercontent.com/ev3dev/brickstrap/master/src/brickstrap.sh
 ./build_sling.sh
-./build_prompt.sh
 ./build_qrcode.sh
 ./build_uuidtob62.sh
 ./build_image.sh

--- a/build_image.sh
+++ b/build_image.sh
@@ -12,7 +12,6 @@ cp ../build-ev3/executables/uuidtob62 executables
 
 # Copy and rename our user executables
 cp ../build-ev3/executables/show_qrcode executables/'Show QR Code'
-cp ../build-ev3/executables/nus_login executables/'Login to NUS_STU'
 cp kill_source.sh executables/'Kill Source Program'
 
 docker build -t sourceacademy/ev3-source .

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -10,7 +10,7 @@ COPY rtl8812cu-driver/8821cu.ko /lib/modules/4.14.117-ev3dev-2.3.5-ev3/drivers/n
 COPY bootstrap.sh start-sling.sh sling.service panel.service show-secret.sh show-qr.sh /usr/local/bin/
 RUN ["bash", "-c", "chmod 755 /usr/local/bin/bootstrap.sh && exec /usr/local/bin/bootstrap.sh"]
 
-# Copy user-executable binaries
+# Copy QR code generator
 ARG show_qrcode="Show QR Code"
 COPY executables/${show_qrcode} /home/robot/
 RUN ["bash", "-c", "chmod 755 \"/home/robot/${show_qrcode}\""]

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -12,9 +12,8 @@ RUN ["bash", "-c", "chmod 755 /usr/local/bin/bootstrap.sh && exec /usr/local/bin
 
 # Copy user-executable binaries
 ARG show_qrcode="Show QR Code"
-ARG nus_login="Login to NUS_STU"
-COPY executables/${show_qrcode} executables/${nus_login} /home/robot/
-RUN ["bash", "-c", "chmod 755 \"/home/robot/${show_qrcode}\" \"/home/robot/${nus_login}\""]
+COPY executables/${show_qrcode} /home/robot/
+RUN ["bash", "-c", "chmod 755 \"/home/robot/${show_qrcode}\""]
 
 # Add script to kill a running Source Program
 ARG kill_source="Kill Source Program"

--- a/image/bootstrap.sh
+++ b/image/bootstrap.sh
@@ -30,8 +30,8 @@ chown robot:robot /var/lib/sling
 
 # install uuidgen
 cd /dev/shm
-curl -LO http://cdn-fastly.deb.debian.org/debian/pool/main/u/util-linux/uuid-runtime_2.29.2-1+deb9u1_armel.deb
-curl -LO http://cdn-fastly.deb.debian.org/debian/pool/main/b/busybox/busybox-static_1.22.0-19+b3_armel.deb
+curl -LO http://archive.debian.org/debian/pool/main/u/util-linux/uuid-runtime_2.29.2-1+deb9u1_armel.deb
+curl -LO http://archive.debian.org/debian/pool/main/b/busybox/busybox-static_1.22.0-19+b3_armel.deb
 dpkg -i uuid-runtime_2.29.2-1+deb9u1_armel.deb
 dpkg -i busybox-static_1.22.0-19+b3_armel.deb
 systemctl disable uuidd.socket


### PR DESCRIPTION
This PR mainly aims to fix apt sources due to Debian 9 (Stretch) becoming EOL, and recently all these sources started giving 404 (since April, only recently noticed).

This PR also removes leftover traces of PEAP login from build scripts (missed in #13).